### PR TITLE
Initial implementation of WiFiManager

### DIFF
--- a/src/Portal.h
+++ b/src/Portal.h
@@ -1,1 +1,0 @@
-#include "thing/Portal.h"

--- a/src/Thing.h
+++ b/src/Thing.h
@@ -1,0 +1,3 @@
+#include "thing/Transcriber.h"
+#include "thing/Portal.h"
+#include "thing/WiFiManager.h"

--- a/src/Transcriber.h
+++ b/src/Transcriber.h
@@ -1,1 +1,0 @@
-#include "thing/Transcriber.h"

--- a/src/thing/Portal.cpp
+++ b/src/thing/Portal.cpp
@@ -9,7 +9,7 @@ Portal::Portal(const Config& config)
       debug_([](const char*){}) {}
 
 void Portal::SetDebugHandler(std::function<void(const char* message)> handler) {
-  debug_ = handler;
+  debug_ = std::move(handler);
 }
 
 void Portal::Start() {
@@ -150,6 +150,8 @@ void Portal::Start() {
       entry["ssid"] = WiFi.SSID(i);
       entry["rssi"] = WiFi.RSSI(i);
     }
+    // Free station info from memory.
+    WiFi.scanDelete();
 
     String buffer;
     data.printTo(buffer);

--- a/src/thing/WiFiManager.cpp
+++ b/src/thing/WiFiManager.cpp
@@ -1,0 +1,69 @@
+#include "thing/WiFiManager.h"
+
+#include <ESP8266WiFi.h>
+#include <DNSServer.h>
+
+
+namespace thing {
+namespace {
+
+const short kDnsPort = 53;
+
+}  // namespace
+
+WiFiManager::WiFiManager() : debug_([](const char*){}) {}
+
+bool WiFiManager::StartAP() {
+  // Use arduino string, casting an int to std::string with arduino C++ support
+  // isn't easy.
+  String ssid("FireThing-");
+  ssid += ESP.getChipId();
+
+  WiFi.mode(WIFI_AP_STA);
+  if (!WiFi.softAP(ssid.c_str())) {
+    return false;
+  }
+
+  debug_((String("WiFi AP : ") + ssid).c_str());
+  debug_((String("Wifi AP IP : ") + WiFi.softAPIP().toString()).c_str());
+
+  dns_.reset(new DNSServer());
+  dns_->start(kDnsPort, "*", WiFi.softAPIP());
+  dns_->setTTL(30);
+
+  ap_up_ = true;
+  return true;
+}
+
+bool WiFiManager::StopAP() {
+  if (!WiFi.softAPdisconnect()) {
+    return false;
+  }
+  dns_->stop();
+  dns_.reset(nullptr);
+
+  ap_up_ = false;
+  return true;
+}
+
+void WiFiManager::Loop() {
+  if (dns_) {
+    dns_->processNextRequest();
+  }
+}
+
+bool WiFiManager::Connect(const std::string& ssid, const std::string& auth) {
+  auto status = WiFi.begin(ssid.c_str(), auth.c_str()); 
+  
+  return status != WL_CONNECT_FAILED;
+}
+
+bool WiFiManager::connected() const {
+  return WiFi.status() == WL_CONNECTED;
+}
+
+void WiFiManager::SetDebugHandler(std::function<void(const char* message)> handler) {
+  debug_ = std::move(handler);
+}
+
+};

--- a/src/thing/WiFiManager.h
+++ b/src/thing/WiFiManager.h
@@ -1,0 +1,31 @@
+#ifndef THING_WIFI_MANAGER_H
+#define THING_WIFI_MANAGER_H
+
+#include <ESP8266WiFi.h>
+#include <DNSServer.h>
+
+namespace thing {
+
+class WiFiManager {
+ public:
+  WiFiManager();
+
+  bool StartAP();
+  bool StopAP();
+  bool Connect(const std::string& ssid, const std::string& auth);
+
+  void Loop();
+
+  bool connected() const;
+  bool ap_up() const { return ap_up_; }
+
+  void SetDebugHandler(std::function<void(const char* message)> handler);
+ private:
+  bool ap_up_ = false;
+  std::unique_ptr<DNSServer> dns_;
+  std::function<void(const char* message)> debug_;
+};
+
+};
+
+#endif // THING_WIFI_MANAGER_H


### PR DESCRIPTION
This is working but there are some kinks that still need to be worked out with the whole system. I want to be able to cleanly keep the portal accessible while the user tests wifi settings. Currently this works if the network they wish to connect to and the Firething's network happen to be on the same channel. We should have a better story for what happens when they aren't. 

This is the last major piece of the Firething, all we need to do now is store the Config in flash when updated. I will implement something for that next and do a lot more testing and tweaking.