### PR TITLE
Fixed a code comment

### DIFF
--- a/src/Firebase.cpp
+++ b/src/Firebase.cpp
@@ -174,7 +174,7 @@ FirebasePush::FirebasePush(const std::string& host, const std::string& auth,
   }
 }
 
-// FirebasePush
+// FirebaseRemove
 FirebaseRemove::FirebaseRemove(const std::string& host, const std::string& auth,
                                const std::string& path,
                                FirebaseHttpClient* http)


### PR DESCRIPTION
I fixed the comment above `FirebaseRemove::FirebaseRemove`.  You probably don't need the comment, but since it's there, it should be right :)