### PR TITLE
Add bi-directional (stream + get/set) support and refactoring of the internal classes 

### DIFF
--- a/contrib/src/modem/command.h
+++ b/contrib/src/modem/command.h
@@ -1,7 +1,7 @@
 #ifndef MODEM_COMMAND_H
 #define MODEM_COMMAND_H
 
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "modem/output-stream.h"
 #include "modem/input-stream.h"
 
@@ -10,19 +10,19 @@ namespace modem {
 
 class Command {
  public:
-  Command(Firebase* fbase) : fbase_(fbase) {}
+  Command(FirebaseArduino* fbase) : fbase_(fbase) {}
 
   // Execute command, reading any additional data needed from stream.
   // Return false if execution failed.
   virtual bool execute(const String& command,
                        InputStream* in, OutputStream* out) = 0;
  protected:
-  Firebase& fbase() {
+  FirebaseArduino& fbase() {
     return *fbase_;
   }
 
  private:
-  Firebase* fbase_;
+  FirebaseArduino* fbase_;
 };
 
 }  // modem

--- a/contrib/src/modem/db/DatabaseProtocol.cpp
+++ b/contrib/src/modem/db/DatabaseProtocol.cpp
@@ -42,7 +42,7 @@ void DatabaseProtocol::Execute(const String& command_name, InputStream* in,
 }
 
 std::unique_ptr<Command> DatabaseProtocol::CreateCommand(const String& text,
-                                                         Firebase* fbase) {
+                                                         FirebaseArduino* fbase) {
   std::unique_ptr<Command> command;
   if (text == "GET") {
     command.reset(new GetCommand(fbase));

--- a/contrib/src/modem/db/DatabaseProtocol.h
+++ b/contrib/src/modem/db/DatabaseProtocol.h
@@ -13,9 +13,9 @@ class DatabaseProtocol : public SerialProtocol {
   const std::vector<String>& commands() const override;
   void Execute(const String& command, InputStream* in, OutputStream* out) override;
  private:
-  std::unique_ptr<Command> CreateCommand(const String& text, Firebase* fbase);
+  std::unique_ptr<Command> CreateCommand(const String& text, FirebaseArduino* fbase);
 
-  std::unique_ptr<Firebase> fbase_;
+  std::unique_ptr<FirebaseArduino> fbase_;
 };
 
 

--- a/contrib/src/modem/db/begin-command.cpp
+++ b/contrib/src/modem/db/begin-command.cpp
@@ -33,13 +33,14 @@ bool BeginCommand::execute(const String& command,
     return false;
   }
 
-  new_firebase_.reset(new Firebase(host.c_str(), auth.c_str()));
+  new_firebase_.reset(new FirebaseArduino());
+  new_firebase_.get()->begin(host.c_str(), auth.c_str());
 
   out->println("+OK");
   return true;
 }
 
-std::unique_ptr<Firebase> BeginCommand::firebase() {
+std::unique_ptr<FirebaseArduino> BeginCommand::firebase() {
   return std::move(new_firebase_);
 }
 

--- a/contrib/src/modem/db/commands.h
+++ b/contrib/src/modem/db/commands.h
@@ -1,7 +1,7 @@
 #ifndef MODEM_DB_COMMANDS_H
 #define MODEM_DB_COMMANDS_H
 
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "modem/command.h"
 #include "modem/output-stream.h"
 #include "modem/input-stream.h"
@@ -11,28 +11,28 @@ namespace modem {
 
 class GetCommand : public Command {
  public:
-  GetCommand(Firebase* fbase) : Command(fbase) {}
+  GetCommand(FirebaseArduino* fbase) : Command(fbase) {}
 
   bool execute(const String& command, InputStream* in, OutputStream* out);
 };
 
 class SetCommand : public Command {
  public:
-  SetCommand(Firebase* fbase) : Command(fbase) {}
+  SetCommand(FirebaseArduino* fbase) : Command(fbase) {}
 
   bool execute(const String& command, InputStream* in, OutputStream* out);
 };
 
 class RemoveCommand : public Command {
  public:
-  RemoveCommand(Firebase* fbase) : Command(fbase) {}
+  RemoveCommand(FirebaseArduino* fbase) : Command(fbase) {}
 
   bool execute(const String& command, InputStream* in, OutputStream* out);
 };
 
 class PushCommand : public Command {
  public:
-  PushCommand(Firebase* fbase) : Command(fbase) {}
+  PushCommand(FirebaseArduino* fbase) : Command(fbase) {}
 
   bool execute(const String& command, InputStream* in, OutputStream* out);
 };
@@ -44,15 +44,15 @@ class BeginCommand : public Command {
   bool execute(const String& command, InputStream* in, OutputStream* out);
 
   // This can only be called once.
-  std::unique_ptr<Firebase> firebase();
+  std::unique_ptr<FirebaseArduino> firebase();
 
  private:
-  std::unique_ptr<Firebase> new_firebase_;
+  std::unique_ptr<FirebaseArduino> new_firebase_;
 };
 
 class StreamCommand : public Command {
  public:
-  StreamCommand(Firebase* fbase) : Command(fbase) {}
+  StreamCommand(FirebaseArduino* fbase) : Command(fbase) {}
 
   bool execute(const String& command, InputStream* in, OutputStream* out);
 };

--- a/contrib/src/modem/db/get-command.cpp
+++ b/contrib/src/modem/db/get-command.cpp
@@ -15,8 +15,7 @@ bool GetCommand::execute(const String& command,
 
   String path = in->readLine();
   String value = fbase().getString(path);
-
-  if (fbase().error().length() == 0) {
+  if (fbase().error().length() != 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/get-command.cpp
+++ b/contrib/src/modem/db/get-command.cpp
@@ -16,7 +16,7 @@ bool GetCommand::execute(const String& command,
   String path = in->readLine();
   String value = fbase().getString(path);
 
-  if (fbase().error()) {
+  if (fbase().error() != "") {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/get-command.cpp
+++ b/contrib/src/modem/db/get-command.cpp
@@ -13,16 +13,15 @@ bool GetCommand::execute(const String& command,
     return false;
   }
 
-  std::string path = in->readLine().c_str();
-  std::unique_ptr<FirebaseGet> get(fbase().getPtr(path));
+  String path = in->readLine();
+  String value = fbase().getString(path);
 
-  if (get->error()) {
+  if (fbase().error()) {
     out->print("-FAIL ");
-    out->println(get->error().message().c_str());
+    out->println(fbase().error().c_str());
     return false;
   }
 
-  String value(get->response().c_str());
   // TODO implement json parsing to pull and process value.
   out->print("+");
   out->println(value);

--- a/contrib/src/modem/db/get-command.cpp
+++ b/contrib/src/modem/db/get-command.cpp
@@ -16,7 +16,7 @@ bool GetCommand::execute(const String& command,
   String path = in->readLine();
   String value = fbase().getString(path);
 
-  if (fbase().error() != "") {
+  if (fbase().error().length() == 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/push-command.cpp
+++ b/contrib/src/modem/db/push-command.cpp
@@ -19,7 +19,7 @@ bool PushCommand::execute(const String& command,
 
   fbase().pushString(path, data);
 
-  if (fbase().error()) {
+  if (fbase().error() != "") {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/push-command.cpp
+++ b/contrib/src/modem/db/push-command.cpp
@@ -14,15 +14,14 @@ bool PushCommand::execute(const String& command,
     return false;
   }
 
-  std::string path(in->readStringUntil(' ').c_str());
-  std::string data(in->readLine().c_str());
+  String path =  in->readStringUntil(' ');
+  String data = in->readLine();
 
-  std::unique_ptr<FirebasePush> push(
-      fbase().pushPtr(path, EncodeForJson(data)));
+  fbase().pushString(path, data);
 
-  if (push->error()) {
+  if (fbase().error()) {
     out->print("-FAIL ");
-    out->println(push->error().message().c_str());
+    out->println(fbase().error().c_str());
     return false;
   } else {
     out->println("+OK");

--- a/contrib/src/modem/db/push-command.cpp
+++ b/contrib/src/modem/db/push-command.cpp
@@ -19,7 +19,7 @@ bool PushCommand::execute(const String& command,
 
   fbase().pushString(path, data);
 
-  if (fbase().error().length() == 0) {
+  if (fbase().error().length() != 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/push-command.cpp
+++ b/contrib/src/modem/db/push-command.cpp
@@ -19,7 +19,7 @@ bool PushCommand::execute(const String& command,
 
   fbase().pushString(path, data);
 
-  if (fbase().error() != "") {
+  if (fbase().error().length() == 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/remove-command.cpp
+++ b/contrib/src/modem/db/remove-command.cpp
@@ -14,11 +14,11 @@ bool RemoveCommand::execute(const String& command,
   }
 
   String path = in->readLine();
-  std::unique_ptr<FirebaseRemove> get(fbase().removePtr(path.c_str()));
+  fbase().remove(path);
 
-  if (get->error()) {
+  if (fbase().error()) {
     out->print("-FAIL ");
-    out->println(get->error().message().c_str());
+    out->println(fbase().error().c_str());
     return false;
   }
 

--- a/contrib/src/modem/db/remove-command.cpp
+++ b/contrib/src/modem/db/remove-command.cpp
@@ -16,7 +16,7 @@ bool RemoveCommand::execute(const String& command,
   String path = in->readLine();
   fbase().remove(path);
 
-  if (fbase().error() != "") {
+  if (fbase().error().length() == 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/remove-command.cpp
+++ b/contrib/src/modem/db/remove-command.cpp
@@ -16,7 +16,7 @@ bool RemoveCommand::execute(const String& command,
   String path = in->readLine();
   fbase().remove(path);
 
-  if (fbase().error().length() == 0) {
+  if (fbase().error().length() != 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/remove-command.cpp
+++ b/contrib/src/modem/db/remove-command.cpp
@@ -16,7 +16,7 @@ bool RemoveCommand::execute(const String& command,
   String path = in->readLine();
   fbase().remove(path);
 
-  if (fbase().error()) {
+  if (fbase().error() != "") {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/set-command.cpp
+++ b/contrib/src/modem/db/set-command.cpp
@@ -19,7 +19,7 @@ bool SetCommand::execute(const String& command,
 
   fbase().setString(path, data);
 
-  if (fbase().error().length() == 0) {
+  if (fbase().error().length() != 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/set-command.cpp
+++ b/contrib/src/modem/db/set-command.cpp
@@ -19,7 +19,7 @@ bool SetCommand::execute(const String& command,
 
   fbase().setString(path, data);
 
-  if (fbase().error()) {
+  if (fbase().error() != "") {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/set-command.cpp
+++ b/contrib/src/modem/db/set-command.cpp
@@ -19,7 +19,7 @@ bool SetCommand::execute(const String& command,
 
   fbase().setString(path, data);
 
-  if (fbase().error() != "") {
+  if (fbase().error().length() == 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/set-command.cpp
+++ b/contrib/src/modem/db/set-command.cpp
@@ -14,15 +14,14 @@ bool SetCommand::execute(const String& command,
     return false;
   }
 
-  std::string path(in->readStringUntil(' ').c_str());
-  std::string data(in->readLine().c_str());
+  String path = in->readStringUntil(' ');
+  String data = in->readLine();
 
-  std::unique_ptr<FirebaseSet> set(fbase().setPtr(path,
-                                                  EncodeForJson(data)));
+  fbase().setString(path, data);
 
-  if (set->error()) {
+  if (fbase().error()) {
     out->print("-FAIL ");
-    out->println(set->error().message().c_str());
+    out->println(fbase().error().c_str());
     return false;
   } else {
     out->println("+OK");

--- a/contrib/src/modem/db/stream-command.cpp
+++ b/contrib/src/modem/db/stream-command.cpp
@@ -16,7 +16,7 @@ bool StreamCommand::execute(const String& command,
   String path = in->readLine().c_str();
   fbase().stream(path);  
 
-  if (fbase().error() != "") {
+  if (fbase().error().length() == 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/stream-command.cpp
+++ b/contrib/src/modem/db/stream-command.cpp
@@ -14,26 +14,24 @@ bool StreamCommand::execute(const String& command,
   }
 
   std::string path = in->readLine().c_str();
-  std::unique_ptr<FirebaseStream> stream(fbase().streamPtr(path));
+  fbase().stream(path);  
 
-  if (stream->error()) {
+  if (fbase().error()) {
     out->print("-FAIL ");
-    out->println(stream->error().message().c_str());
+    out->println(fbase().error().c_str());
     return false;
   }
 
   bool running = true;
   DynamicJsonBuffer buffer;
   while(running) {
-    if (stream->available()) {
-      std::string json;
-      FirebaseStream::Event event = stream->read(json);
+    if (fbase().available()) {
+      FirebaseObject event = fbase().readEvent();
       out->print("+");
-      out->print(FirebaseStream::EventToName(event).c_str());
+      out->print(event.getString("event").c_str());
       out->print(" ");
-      const auto& object = buffer.parseObject(json.c_str());
-      String data = object["data"].asString();
-      out->println(object["path"].asString());
+      String data = event.getString("data");
+      out->println(event.getString("path"));
       out->println(data.length());
       out->println(data);
     } else if (in->available()) {

--- a/contrib/src/modem/db/stream-command.cpp
+++ b/contrib/src/modem/db/stream-command.cpp
@@ -16,7 +16,7 @@ bool StreamCommand::execute(const String& command,
   String path = in->readLine().c_str();
   fbase().stream(path);  
 
-  if (fbase().error().length() == 0) {
+  if (fbase().error().length() != 0) {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/src/modem/db/stream-command.cpp
+++ b/contrib/src/modem/db/stream-command.cpp
@@ -21,14 +21,13 @@ bool StreamCommand::execute(const String& command,
     out->println(fbase().error().c_str());
     return false;
   }
-
   bool running = true;
   DynamicJsonBuffer buffer;
   while(running) {
     if (fbase().available()) {
       FirebaseObject event = fbase().readEvent();
       out->print("+");
-      out->print(event.getString("event").c_str());
+      out->print(event.getString("type").c_str());
       out->print(" ");
       String data = event.getString("data");
       out->println(event.getString("path"));

--- a/contrib/src/modem/db/stream-command.cpp
+++ b/contrib/src/modem/db/stream-command.cpp
@@ -13,10 +13,10 @@ bool StreamCommand::execute(const String& command,
     return false;
   }
 
-  std::string path = in->readLine().c_str();
+  String path = in->readLine().c_str();
   fbase().stream(path);  
 
-  if (fbase().error()) {
+  if (fbase().error() != "") {
     out->print("-FAIL ");
     out->println(fbase().error().c_str());
     return false;

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -20,21 +20,6 @@ class MockFirebase : public FirebaseArduino {
   MOCK_CONST_METHOD2(begin, void (const String& host, const String& auth));
 };
 
-
-class MockFirebaseRequest : public FirebaseRequest {
- public:
-  MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(response, const std::string&());
-  MOCK_CONST_METHOD0(error, const FirebaseError&());
-};
-
-class MockFirebaseStream : public FirebaseStream {
- public:
-  MOCK_METHOD0(available, bool());
-  MOCK_METHOD1(read, Event(std::string& event));
-  MOCK_CONST_METHOD0(error, const FirebaseError&());
-};
-
 }  // modem
 }  // firebase
 #endif  // TEST_MOCK_FIREBASE_H

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -11,13 +11,13 @@ namespace modem {
 class MockFirebase : public FirebaseArduino {
  public:
   MOCK_CONST_METHOD0(error, const FirebaseError&());
-  MOCK_CONST_METHOD1(getString, String ());
-  MOCK_CONST_METHOD2(pushString, void());
-  MOCK_CONST_METHOD1(remove, void());
-  MOCK_CONST_METHOD2(setString, void());
+  MOCK_CONST_METHOD1(getString, String (const String& path));
+  MOCK_CONST_METHOD2(pushString, void(const String& path, const String& data));
+  MOCK_CONST_METHOD1(remove, void(const String& path));
+  MOCK_CONST_METHOD2(setString, void(const String& path, const String& data));
   MOCK_CONST_METHOD0(available, bool ());
   MOCK_CONST_METHOD0(readEvent, FirebaseObject ());
-  MOCK_CONST_METHOD2(begin, void ());
+  MOCK_CONST_METHOD2(begin, void (const String& host, const String& auth));
 };
 
 

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -10,14 +10,14 @@ namespace modem {
 
 class MockFirebase : public FirebaseArduino {
  public:
-  MOCK_CONST_METHOD0(error, const String &());
-  MOCK_CONST_METHOD1(getString, String (const String& path));
-  MOCK_CONST_METHOD2(pushString, void(const String& path, const String& data));
-  MOCK_CONST_METHOD1(remove, void(const String& path));
-  MOCK_CONST_METHOD2(setString, void(const String& path, const String& data));
-  MOCK_CONST_METHOD0(available, bool ());
-  MOCK_CONST_METHOD0(readEvent, FirebaseObject ());
-  MOCK_CONST_METHOD2(begin, void (const String& host, const String& auth));
+  MOCK_METHOD0(error, const String &());
+  MOCK_METHOD1(getString, String (const String& path));
+  MOCK_METHOD2(pushString, String (const String& path, const String& data));
+  MOCK_METHOD1(remove, void(const String& path));
+  MOCK_METHOD2(setString, void(const String& path, const String& data));
+  MOCK_METHOD0(available, bool ());
+  MOCK_METHOD0(readEvent, FirebaseObject ());
+  MOCK_METHOD2(begin, void (const String& host, const String& auth));
 };
 
 }  // modem

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -10,7 +10,7 @@ namespace modem {
 
 class MockFirebase : public FirebaseArduino {
  public:
-  MOCK_CONST_METHOD0(error, const FirebaseError&());
+  MOCK_CONST_METHOD0(error, const String &());
   MOCK_CONST_METHOD1(getString, String (const String& path));
   MOCK_CONST_METHOD2(pushString, void(const String& path, const String& data));
   MOCK_CONST_METHOD1(remove, void(const String& path));

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -16,6 +16,7 @@ class MockFirebase : public Firebase {
 class MockFirebaseRequest : public FirebaseRequest {
  public:
   MOCK_CONST_METHOD0(name, const std::string&());
+  MOCK_CONST_METHOD0(reponse, const std::string&());
   MOCK_CONST_METHOD0(error, const FirebaseError&());
 };
 

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -18,6 +18,7 @@ class MockFirebase : public FirebaseArduino {
   MOCK_METHOD0(available, bool ());
   MOCK_METHOD0(readEvent, FirebaseObject ());
   MOCK_METHOD2(begin, void (const String& host, const String& auth));
+  MOCK_METHOD1(stream, void (const String& path));
 };
 
 }  // modem

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -16,7 +16,7 @@ class MockFirebase : public Firebase {
 class MockFirebaseRequest : public FirebaseRequest {
  public:
   MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(reponse, const std::string&());
+  MOCK_CONST_METHOD0(response, const std::string&());
   MOCK_CONST_METHOD0(error, const FirebaseError&());
 };
 

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -10,33 +10,12 @@ namespace modem {
 
 class MockFirebase : public Firebase {
  public:
-  MOCK_METHOD1(getPtr, std::unique_ptr<FirebaseGet>(const std::string&));
-  MOCK_METHOD2(setPtr, std::unique_ptr<FirebaseSet>(const std::string&, const std::string&));
-  MOCK_METHOD2(pushPtr, std::unique_ptr<FirebasePush>(const std::string&, const std::string&));
-  MOCK_METHOD1(removePtr, std::unique_ptr<FirebaseRemove>(const std::string&));
-  MOCK_METHOD1(streamPtr, std::unique_ptr<FirebaseStream>(const std::string&));
 };
 
-class MockFirebaseGet : public FirebaseGet {
- public:
-  MOCK_CONST_METHOD0(response, const std::string&());
-  MOCK_CONST_METHOD0(error, const FirebaseError&());
-};
 
-class MockFirebaseSet : public FirebaseSet {
- public:
-  MOCK_CONST_METHOD0(json, const std::string&());
-  MOCK_CONST_METHOD0(error, const FirebaseError&());
-};
-
-class MockFirebasePush : public FirebasePush {
+class MockFirebaseRequest : public FirebaseRequest {
  public:
   MOCK_CONST_METHOD0(name, const std::string&());
-  MOCK_CONST_METHOD0(error, const FirebaseError&());
-};
-
-class MockFirebaseRemove : public FirebaseRemove {
- public:
   MOCK_CONST_METHOD0(error, const FirebaseError&());
 };
 

--- a/contrib/test/mock-firebase.h
+++ b/contrib/test/mock-firebase.h
@@ -3,13 +3,21 @@
 
 #include <memory>
 #include "gtest/gtest.h"
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 
 namespace firebase {
 namespace modem {
 
-class MockFirebase : public Firebase {
+class MockFirebase : public FirebaseArduino {
  public:
+  MOCK_CONST_METHOD0(error, const FirebaseError&());
+  MOCK_CONST_METHOD1(getString, String ());
+  MOCK_CONST_METHOD2(pushString, void());
+  MOCK_CONST_METHOD1(remove, void());
+  MOCK_CONST_METHOD2(setString, void());
+  MOCK_CONST_METHOD0(available, bool ());
+  MOCK_CONST_METHOD0(readEvent, FirebaseObject ());
+  MOCK_CONST_METHOD2(begin, void ());
 };
 
 

--- a/contrib/test/modem/Makefile
+++ b/contrib/test/modem/Makefile
@@ -55,8 +55,9 @@ CXXFLAGS += -g -Wall -Wextra -pthread -std=c++11
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
 TESTS = get-command_test set-command_test remove-command_test \
-	push-command_test begin-command_test stream-command_test \
+	push-command_test begin-command_test \
 	serial-transceiver_test
+#       stream-command_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -130,8 +131,14 @@ arduino_mock_all.a : ArduinoMockAll.o
 
 # Builds shared objects.
 
-Firebase.o : $(FIREBASE_SRC_ROOT)/FirebaseArduino.cpp
+FirebaseArduino.o : $(FIREBASE_SRC_ROOT)/FirebaseArduino.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(FIREBASE_SRC_ROOT)/FirebaseArduino.cpp
+
+FirebaseObject.o : $(FIREBASE_SRC_ROOT)/FirebaseObject.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(FIREBASE_SRC_ROOT)/FirebaseObject.cpp
+
+Firebase.o : $(FIREBASE_SRC_ROOT)/Firebase.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(FIREBASE_SRC_ROOT)/Firebase.cpp
 
 FirebaseHttpClient_dummy.o : $(PROJECT_ROOT)/test/dummies/FirebaseHttpClient_dummy.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(PROJECT_ROOT)/test/dummies/FirebaseHttpClient_dummy.cpp
@@ -144,7 +151,7 @@ get-command.o : $(SRC_ROOT)/modem/db/get-command.cpp
 get-command_test.o : $(TEST_DIR)/get-command_test.cpp $(GMOCK_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/get-command_test.cpp
 
-get-command_test : get-command_test.o Firebase.o FirebaseHttpClient_dummy.o get-command.o gmock_main.a \
+get-command_test : get-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o get-command.o gmock_main.a \
 		arduino_mock_all.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
@@ -155,7 +162,7 @@ set-command.o : $(SRC_ROOT)/modem/db/set-command.cpp
 set-command_test.o : $(TEST_DIR)/set-command_test.cpp $(GMOCK_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/set-command_test.cpp
 
-set-command_test : set-command.o set-command_test.o Firebase.o FirebaseHttpClient_dummy.o gmock_main.a \
+set-command_test : set-command.o set-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
 		arduino_mock_all.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
@@ -166,7 +173,7 @@ remove-command.o : $(SRC_ROOT)/modem/db/remove-command.cpp
 remove-command_test.o : $(TEST_DIR)/remove-command_test.cpp $(GMOCK_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/remove-command_test.cpp
 
-remove-command_test : remove-command.o remove-command_test.o Firebase.o FirebaseHttpClient_dummy.o gmock_main.a \
+remove-command_test : remove-command.o remove-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
 		arduino_mock_all.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
@@ -177,7 +184,7 @@ push-command.o : $(SRC_ROOT)/modem/db/push-command.cpp
 push-command_test.o : $(TEST_DIR)/push-command_test.cpp $(GMOCK_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/push-command_test.cpp
 
-push-command_test : push-command.o push-command_test.o Firebase.o FirebaseHttpClient_dummy.o gmock_main.a \
+push-command_test : push-command.o push-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
 		arduino_mock_all.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
@@ -188,20 +195,20 @@ begin-command.o : $(SRC_ROOT)/modem/db/begin-command.cpp
 begin-command_test.o : $(TEST_DIR)/begin-command_test.cpp $(GMOCK_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/begin-command_test.cpp
 
-begin-command_test : begin-command.o begin-command_test.o Firebase.o FirebaseHttpClient_dummy.o gmock_main.a \
+begin-command_test : begin-command.o begin-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
 		arduino_mock_all.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 
-stream-command.o : $(SRC_ROOT)/modem/db/stream-command.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(SRC_ROOT)/modem/db/stream-command.cpp
-
-stream-command_test.o : $(TEST_DIR)/stream-command_test.cpp $(GMOCK_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/stream-command_test.cpp
-
-stream-command_test : stream-command.o stream-command_test.o Firebase.o FirebaseHttpClient_dummy.o gmock_main.a \
+#stream-command.o : $(SRC_ROOT)/modem/db/stream-command.cpp
+#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(SRC_ROOT)/modem/db/stream-command.cpp
+#
+#stream-command_test.o : $(TEST_DIR)/stream-command_test.cpp $(GMOCK_HEADERS)
+#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/stream-command_test.cpp
+#
+#stream-command_test : stream-command.o stream-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
 		arduino_mock_all.a
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 
 SerialTransceiver.o : $(SRC_ROOT)/modem/SerialTransceiver.cpp

--- a/contrib/test/modem/Makefile
+++ b/contrib/test/modem/Makefile
@@ -56,8 +56,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread -std=c++11
 # created to the list.
 TESTS = get-command_test set-command_test remove-command_test \
 	push-command_test begin-command_test \
-	serial-transceiver_test
-#       stream-command_test
+	serial-transceiver_test stream-command_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -200,15 +199,15 @@ begin-command_test : begin-command.o begin-command_test.o FirebaseArduino.o Fire
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 
-#stream-command.o : $(SRC_ROOT)/modem/db/stream-command.cpp
-#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(SRC_ROOT)/modem/db/stream-command.cpp
-#
-#stream-command_test.o : $(TEST_DIR)/stream-command_test.cpp $(GMOCK_HEADERS)
-#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/stream-command_test.cpp
-#
-#stream-command_test : stream-command.o stream-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
+stream-command.o : $(SRC_ROOT)/modem/db/stream-command.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(SRC_ROOT)/modem/db/stream-command.cpp
+
+stream-command_test.o : $(TEST_DIR)/stream-command_test.cpp $(GMOCK_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/stream-command_test.cpp
+
+stream-command_test : stream-command.o stream-command_test.o FirebaseArduino.o Firebase.o FirebaseObject.o FirebaseHttpClient_dummy.o gmock_main.a \
 		arduino_mock_all.a
-#	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 
 SerialTransceiver.o : $(SRC_ROOT)/modem/SerialTransceiver.cpp

--- a/contrib/test/modem/Makefile
+++ b/contrib/test/modem/Makefile
@@ -130,8 +130,8 @@ arduino_mock_all.a : ArduinoMockAll.o
 
 # Builds shared objects.
 
-Firebase.o : $(FIREBASE_SRC_ROOT)/Firebase.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(FIREBASE_SRC_ROOT)/Firebase.cpp
+Firebase.o : $(FIREBASE_SRC_ROOT)/FirebaseArduino.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(FIREBASE_SRC_ROOT)/FirebaseArduino.cpp
 
 FirebaseHttpClient_dummy.o : $(PROJECT_ROOT)/test/dummies/FirebaseHttpClient_dummy.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(PROJECT_ROOT)/test/dummies/FirebaseHttpClient_dummy.cpp

--- a/contrib/test/modem/begin-command_test.cpp
+++ b/contrib/test/modem/begin-command_test.cpp
@@ -52,8 +52,7 @@ TEST_F(BeginCommandTest, hostOnly) {
   BeginCommand command;
   ASSERT_TRUE(command.execute("BEGIN_DB", &in_, &out_));
 
-  std::unique_ptr<Firebase> firebase(command.firebase());
-  EXPECT_EQ("", firebase->auth());
+  std::unique_ptr<FirebaseArduino> firebase(command.firebase());
 }
 
 TEST_F(BeginCommandTest, hostAndAuth) {
@@ -66,8 +65,7 @@ TEST_F(BeginCommandTest, hostAndAuth) {
   BeginCommand command;
   ASSERT_TRUE(command.execute("BEGIN_DB", &in_, &out_));
 
-  std::unique_ptr<Firebase> firebase(command.firebase());
-  EXPECT_EQ(auth, firebase->auth());
+  std::unique_ptr<FirebaseArduino> firebase(command.firebase());
 }
 
 TEST_F(BeginCommandTest, neitherHostNorAuth) {
@@ -77,7 +75,7 @@ TEST_F(BeginCommandTest, neitherHostNorAuth) {
   BeginCommand command;
   ASSERT_FALSE(command.execute("BEGIN_DB", &in_, &out_));
 
-  std::unique_ptr<Firebase> firebase(command.firebase());
+  std::unique_ptr<FirebaseArduino> firebase(command.firebase());
   EXPECT_FALSE(firebase);
 }
 }  // modem

--- a/contrib/test/modem/begin-command_test.cpp
+++ b/contrib/test/modem/begin-command_test.cpp
@@ -1,4 +1,4 @@
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "gtest/gtest.h"
 #include "modem/db/commands.h"
 #include "test/modem/mock-input-stream.h"

--- a/contrib/test/modem/get-command_test.cpp
+++ b/contrib/test/modem/get-command_test.cpp
@@ -37,11 +37,12 @@ class GetCommandTest : public ::testing::Test {
 TEST_F(GetCommandTest, gets) {
   const String path("/test/path");
   const String command_fragment(" /test/path");
-  const String no_error = "";
   FeedCommand(path);
 
   const String value("Test value");
   EXPECT_CALL(fbase_, getString(command_fragment)).WillOnce(Return("Test value"));
+
+  const String no_error = "";
   EXPECT_CALL(fbase_, error()).WillOnce(ReturnRef(no_error));
 
   EXPECT_CALL(out_, print(String("+")))
@@ -57,10 +58,11 @@ TEST_F(GetCommandTest, handlesError) {
   FirebaseError error(-200, "Test Error.");
   const String command_fragment(" /test/path");
   const String path("/test/path");
-  const String error_value = "Test Error.";
   FeedCommand(path);
 
+  const String error_value = "Test Error.";
   EXPECT_CALL(fbase_, error()).WillRepeatedly(ReturnRef(error_value));
+
   EXPECT_CALL(fbase_, getString(command_fragment)).WillOnce(Return(""));
 
   EXPECT_CALL(out_, print(String("-FAIL ")))

--- a/contrib/test/modem/get-command_test.cpp
+++ b/contrib/test/modem/get-command_test.cpp
@@ -20,7 +20,7 @@ class GetCommandTest : public ::testing::Test {
 
   void FeedCommand(const String& path) {
     const String command_fragment(String(" ") + path);
-    EXPECT_CALL(in_, readLine())
+     EXPECT_CALL(in_, readLine())
         .WillOnce(Return(command_fragment));
   }
 
@@ -36,9 +36,13 @@ class GetCommandTest : public ::testing::Test {
 
 TEST_F(GetCommandTest, gets) {
   const String path("/test/path");
+  const String command_fragment(" /test/path");
+  const String no_error = "";
   FeedCommand(path);
 
   const String value("Test value");
+  EXPECT_CALL(fbase_, getString(command_fragment)).WillOnce(Return("Test value"));
+  EXPECT_CALL(fbase_, error()).WillOnce(ReturnRef(no_error));
 
   EXPECT_CALL(out_, print(String("+")))
       .WillOnce(Return(1));
@@ -51,13 +55,18 @@ TEST_F(GetCommandTest, gets) {
 
 TEST_F(GetCommandTest, handlesError) {
   FirebaseError error(-200, "Test Error.");
+  const String command_fragment(" /test/path");
   const String path("/test/path");
+  const String error_value = "Test Error.";
   FeedCommand(path);
+
+  EXPECT_CALL(fbase_, error()).WillRepeatedly(ReturnRef(error_value));
+  EXPECT_CALL(fbase_, getString(command_fragment)).WillOnce(Return(""));
 
   EXPECT_CALL(out_, print(String("-FAIL ")))
       .WillOnce(Return(1));
 
-  EXPECT_CALL(out_, println(String(error.message().c_str())))
+  EXPECT_CALL(out_, println(error_value))
       .WillOnce(Return(1));
   ASSERT_FALSE(RunCommand(error));
 

--- a/contrib/test/modem/get-command_test.cpp
+++ b/contrib/test/modem/get-command_test.cpp
@@ -16,7 +16,6 @@ using ::testing::_;
 class GetCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    get_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path) {
@@ -26,9 +25,6 @@ class GetCommandTest : public ::testing::Test {
   }
 
   bool RunCommand(const FirebaseError& error) {
-    EXPECT_CALL(*get_, error())
-      .WillRepeatedly(ReturnRef(error));
-
     GetCommand getCmd(&fbase_);
     return getCmd.execute("GET", &in_, &out_);
   }
@@ -36,7 +32,6 @@ class GetCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseRequest> get_;
 };
 
 TEST_F(GetCommandTest, gets) {
@@ -44,8 +39,6 @@ TEST_F(GetCommandTest, gets) {
   FeedCommand(path);
 
   const String value("Test value");
-  EXPECT_CALL(*get_, response())
-      .WillOnce(ReturnRef(value));
 
   EXPECT_CALL(out_, print(String("+")))
       .WillOnce(Return(1));

--- a/contrib/test/modem/get-command_test.cpp
+++ b/contrib/test/modem/get-command_test.cpp
@@ -16,7 +16,7 @@ using ::testing::_;
 class GetCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    get_.reset(new MockFirebaseGet());
+    get_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path) {
@@ -39,7 +39,7 @@ class GetCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseGet> get_;
+  std::unique_ptr<MockFirebaseRequest> get_;
 };
 
 TEST_F(GetCommandTest, gets) {

--- a/contrib/test/modem/get-command_test.cpp
+++ b/contrib/test/modem/get-command_test.cpp
@@ -29,9 +29,6 @@ class GetCommandTest : public ::testing::Test {
     EXPECT_CALL(*get_, error())
       .WillRepeatedly(ReturnRef(error));
 
-    EXPECT_CALL(fbase_, getPtr(_))
-        .WillOnce(Return(ByMove(std::move(get_))));
-
     GetCommand getCmd(&fbase_);
     return getCmd.execute("GET", &in_, &out_);
   }

--- a/contrib/test/modem/get-command_test.cpp
+++ b/contrib/test/modem/get-command_test.cpp
@@ -1,4 +1,4 @@
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "gtest/gtest.h"
 #include "modem/db/commands.h"
 #include "test/modem/mock-input-stream.h"

--- a/contrib/test/modem/push-command_test.cpp
+++ b/contrib/test/modem/push-command_test.cpp
@@ -17,7 +17,7 @@ using ::testing::_;
 class PushCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    push_.reset(new MockFirebasePush());
+    push_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path, const String& data) {
@@ -54,7 +54,7 @@ class PushCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebasePush> push_;
+  std::unique_ptr<MockFirebaseRequest> push_;
 };
 
 TEST_F(PushCommandTest, sendsData) {

--- a/contrib/test/modem/push-command_test.cpp
+++ b/contrib/test/modem/push-command_test.cpp
@@ -39,7 +39,7 @@ class PushCommandTest : public ::testing::Test {
         .WillOnce(Return(error_message.length()));
   }
 
-  bool RunExpectingData(const String& data, const FirebaseError& error) {
+  bool RunCommand() {
     PushCommand pushCmd(&fbase_);
     return pushCmd.execute("PUSH", &in_, &out_);
   }
@@ -54,22 +54,26 @@ TEST_F(PushCommandTest, sendsData) {
   const String data("This is a test payload.");
 
   FeedCommand(path, data);
+  const String no_error = "";
+  EXPECT_CALL(fbase_, error()).WillOnce(ReturnRef(no_error));
+
   ExpectOutput("+OK");
 
-  ASSERT_TRUE(RunExpectingData(data, FirebaseError()));
+  ASSERT_TRUE(RunCommand());
 }
 
 TEST_F(PushCommandTest, HandlesError) {
   const String path("/test/path");
   const String data("This is a test payload.");
-  FirebaseError error(-200, "Test error.");
 
   FeedCommand(path, data);
-  ExpectErrorOutput(error.message());
+  const String error = "Test Error.";
+  EXPECT_CALL(fbase_, error()).WillRepeatedly(ReturnRef(error));
 
-  ASSERT_FALSE(RunExpectingData(data, error));
+  ExpectErrorOutput(error);
+
+  ASSERT_FALSE(RunCommand());
 }
 
 }  // modem
 }  // firebase
-

--- a/contrib/test/modem/push-command_test.cpp
+++ b/contrib/test/modem/push-command_test.cpp
@@ -17,7 +17,6 @@ using ::testing::_;
 class PushCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    push_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path, const String& data) {
@@ -41,12 +40,6 @@ class PushCommandTest : public ::testing::Test {
   }
 
   bool RunExpectingData(const String& data, const FirebaseError& error) {
-    EXPECT_CALL(*push_, error())
-      .WillRepeatedly(ReturnRef(error));
-
-    EXPECT_CALL(fbase_, pushPtr(_, EncodeForJson(data)))
-        .WillOnce(Return(ByMove(std::move(push_))));
-
     PushCommand pushCmd(&fbase_);
     return pushCmd.execute("PUSH", &in_, &out_);
   }
@@ -54,7 +47,6 @@ class PushCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseRequest> push_;
 };
 
 TEST_F(PushCommandTest, sendsData) {

--- a/contrib/test/modem/push-command_test.cpp
+++ b/contrib/test/modem/push-command_test.cpp
@@ -1,4 +1,4 @@
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "gtest/gtest.h"
 #include "modem/db/commands.h"
 #include "modem/json_util.h"

--- a/contrib/test/modem/remove-command_test.cpp
+++ b/contrib/test/modem/remove-command_test.cpp
@@ -2,7 +2,7 @@
 #include "test/modem/mock-output-stream.h"
 #include "test/modem/mock-input-stream.h"
 #include "test/mock-firebase.h"
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "modem/db/commands.h"
 
 namespace firebase {

--- a/contrib/test/modem/remove-command_test.cpp
+++ b/contrib/test/modem/remove-command_test.cpp
@@ -16,7 +16,7 @@ using ::testing::_;
 class RemoveCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    remove_.reset(new MockFirebaseRemove());
+    remove_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path) {
@@ -39,7 +39,7 @@ class RemoveCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseRemove> remove_;
+  std::unique_ptr<MockFirebaseRequest> remove_;
 };
 
 TEST_F(RemoveCommandTest, success) {

--- a/contrib/test/modem/remove-command_test.cpp
+++ b/contrib/test/modem/remove-command_test.cpp
@@ -24,8 +24,7 @@ class RemoveCommandTest : public ::testing::Test {
         .WillOnce(Return(command_fragment));
   }
 
-  bool RunCommand(const FirebaseError& error) {
-
+  bool RunCommand() {
     RemoveCommand command(&fbase_);
     return command.execute("REMOVE", &in_, &out_);
   }
@@ -39,23 +38,28 @@ TEST_F(RemoveCommandTest, success) {
   const String path("/test/path");
   FeedCommand(path);
 
+  const String no_error = "";
+  EXPECT_CALL(fbase_, error()).WillOnce(ReturnRef(no_error));
+
   EXPECT_CALL(out_, println(String("+OK")))
       .WillOnce(Return(3));
 
-  ASSERT_TRUE(RunCommand(FirebaseError()));
+  ASSERT_TRUE(RunCommand());
 }
 
 TEST_F(RemoveCommandTest, handlesError) {
-  FirebaseError error(-200, "Test Error.");
   const String path("/test/path");
   FeedCommand(path);
 
   EXPECT_CALL(out_, print(String("-FAIL ")))
       .WillOnce(Return(1));
 
-  EXPECT_CALL(out_, println(String(error.message().c_str())))
+  const String error = "Test Error.";
+  EXPECT_CALL(fbase_, error()).WillRepeatedly(ReturnRef(error));
+
+  EXPECT_CALL(out_, println(String(error.c_str())))
       .WillOnce(Return(1));
-  ASSERT_FALSE(RunCommand(error));
+  ASSERT_FALSE(RunCommand());
 }
 
 }  // modem

--- a/contrib/test/modem/remove-command_test.cpp
+++ b/contrib/test/modem/remove-command_test.cpp
@@ -16,7 +16,6 @@ using ::testing::_;
 class RemoveCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    remove_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path) {
@@ -26,11 +25,6 @@ class RemoveCommandTest : public ::testing::Test {
   }
 
   bool RunCommand(const FirebaseError& error) {
-    EXPECT_CALL(*remove_, error())
-      .WillRepeatedly(ReturnRef(error));
-
-    EXPECT_CALL(fbase_, removePtr(_))
-        .WillOnce(Return(ByMove(std::move(remove_))));
 
     RemoveCommand command(&fbase_);
     return command.execute("REMOVE", &in_, &out_);
@@ -39,7 +33,6 @@ class RemoveCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseRequest> remove_;
 };
 
 TEST_F(RemoveCommandTest, success) {

--- a/contrib/test/modem/serial-transceiver_test.cpp
+++ b/contrib/test/modem/serial-transceiver_test.cpp
@@ -1,6 +1,6 @@
 #include <vector>
 
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "gtest/gtest.h"
 #include "modem/SerialTransceiver.h"
 

--- a/contrib/test/modem/set-command_test.cpp
+++ b/contrib/test/modem/set-command_test.cpp
@@ -39,8 +39,7 @@ class SetCommandTest : public ::testing::Test {
         .WillOnce(Return(error_message.length()));
   }
 
-  bool RunExpectingData(const String& data, const FirebaseError& error) {
-
+  bool RunCommand() {
     SetCommand setCmd(&fbase_);
     return setCmd.execute("SET", &in_, &out_);
   }
@@ -53,22 +52,25 @@ class SetCommandTest : public ::testing::Test {
 TEST_F(SetCommandTest, sendsData) {
   const String path("/test/path");
   const String data("This is a test payload.");
+  const String no_error = "";
+  EXPECT_CALL(fbase_, error()).WillOnce(ReturnRef(no_error));
 
   FeedCommand(path, data);
   ExpectOutput("+OK");
 
-  ASSERT_TRUE(RunExpectingData(data, FirebaseError()));
+  ASSERT_TRUE(RunCommand());
 }
 
 TEST_F(SetCommandTest, HandlesError) {
   const String path("/test/path");
   const String data("This is a test payload.");
-  FirebaseError error(-200, "Test error.");
+  const String error = "TestError";
+  EXPECT_CALL(fbase_, error()).WillRepeatedly(ReturnRef(error));
 
   FeedCommand(path, data);
-  ExpectErrorOutput(error.message());
+  ExpectErrorOutput(error);
 
-  ASSERT_FALSE(RunExpectingData(data, error));
+  ASSERT_FALSE(RunCommand());
 }
 }  // modem
 }  // firebase

--- a/contrib/test/modem/set-command_test.cpp
+++ b/contrib/test/modem/set-command_test.cpp
@@ -17,7 +17,6 @@ using ::testing::_;
 class SetCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    set_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path, const String& data) {
@@ -41,11 +40,6 @@ class SetCommandTest : public ::testing::Test {
   }
 
   bool RunExpectingData(const String& data, const FirebaseError& error) {
-    EXPECT_CALL(*set_, error())
-      .WillRepeatedly(ReturnRef(error));
-
-    EXPECT_CALL(fbase_, setPtr(_, EncodeForJson(data)))
-        .WillOnce(Return(ByMove(std::move(set_))));
 
     SetCommand setCmd(&fbase_);
     return setCmd.execute("SET", &in_, &out_);
@@ -54,7 +48,6 @@ class SetCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseRequest> set_;
 };
 
 TEST_F(SetCommandTest, sendsData) {

--- a/contrib/test/modem/set-command_test.cpp
+++ b/contrib/test/modem/set-command_test.cpp
@@ -1,4 +1,4 @@
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "gtest/gtest.h"
 #include "modem/db/commands.h"
 #include "modem/json_util.h"

--- a/contrib/test/modem/set-command_test.cpp
+++ b/contrib/test/modem/set-command_test.cpp
@@ -17,7 +17,7 @@ using ::testing::_;
 class SetCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    set_.reset(new MockFirebaseSet());
+    set_.reset(new MockFirebaseRequest());
   }
 
   void FeedCommand(const String& path, const String& data) {
@@ -54,7 +54,7 @@ class SetCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseSet> set_;
+  std::unique_ptr<MockFirebaseRequest> set_;
 };
 
 TEST_F(SetCommandTest, sendsData) {

--- a/contrib/test/modem/stream-command_test.cpp
+++ b/contrib/test/modem/stream-command_test.cpp
@@ -17,16 +17,10 @@ using ::testing::_;
 class StreamCommandTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    stream_.reset(new MockFirebaseStream());
+    stream_.reset(new FirebaseStream());
   }
 
   bool RunCommand(const FirebaseError& error) {
-    EXPECT_CALL(*stream_, error())
-      .WillRepeatedly(ReturnRef(error));
-
-    EXPECT_CALL(fbase_, streamPtr(_))
-        .WillOnce(Return(ByMove(std::move(stream_))));
-
     StreamCommand cmd(&fbase_);
     return cmd.execute("BEGIN_STREAM", &in_, &out_);
   }
@@ -34,7 +28,7 @@ class StreamCommandTest : public ::testing::Test {
   MockInputStream in_;
   MockOutputStream out_;
   MockFirebase fbase_;
-  std::unique_ptr<MockFirebaseStream> stream_;
+  std::unique_ptr<FirebaseStream> stream_;
 };
 
 TEST_F(StreamCommandTest, streams) {
@@ -48,10 +42,11 @@ TEST_F(StreamCommandTest, streams) {
 
   const String data = "Test Value";
   const String value(String("{\"path\" : \"/test/path\", \"data\" : \"") + data + "\"}");
-  EXPECT_CALL(*stream_, available())
-      .WillOnce(Return(true))
-      .WillRepeatedly(Return(false));
+    EXPECT_CALL(fbase_, available())
+     .WillOnce(Return(true))
+     .WillRepeatedly(Return(false));
 
+  EXPECT_CALL(fbase_, startStreaming());
   EXPECT_CALL(*stream_, read(_))
       .WillOnce(Invoke([&value](std::string& json) {
         json = value.c_str();

--- a/contrib/test/modem/stream-command_test.cpp
+++ b/contrib/test/modem/stream-command_test.cpp
@@ -1,4 +1,4 @@
-#include "Firebase.h"
+#include "FirebaseArduino.h"
 #include "gtest/gtest.h"
 #include "modem/db/commands.h"
 #include "test/modem/mock-input-stream.h"

--- a/src/Firebase.cpp
+++ b/src/Firebase.cpp
@@ -97,27 +97,3 @@ void FirebaseStream::startStreaming(const std::string& host, const std::string& 
       status = http_->sendRequest("GET", std::string());
   }
 }
-
-bool FirebaseStream::available() {
-  auto client = http_->getStreamPtr();
-  return (client == nullptr) ? false : client->available();
-}
-
-FirebaseStream::Event FirebaseStream::read(std::string& event) {
-  auto client = http_->getStreamPtr();
-  if (client == nullptr) { 
-      return Event();
-  } 
-  Event type;
-  std::string typeStr = client->readStringUntil('\n').substring(7).c_str();
-  if (typeStr == "put") {
-    type = Event::PUT;
-  } else if (typeStr == "patch") {
-    type = Event::PATCH;
-  } else {
-    type = Event::UNKNOWN;
-  }
-  event = client->readStringUntil('\n').substring(6).c_str();
-  client->readStringUntil('\n'); // consume separator
-  return type;
-}

--- a/src/Firebase.h
+++ b/src/Firebase.h
@@ -99,32 +99,7 @@ class FirebaseStream : public FirebaseCall {
   FirebaseStream(const std::shared_ptr<FirebaseHttpClient> http = NULL) : FirebaseCall(http) { }
   virtual ~FirebaseStream() {}
 
-  // Return if there is any event available to read.
-  bool available();
   void startStreaming(const std::string& host, const std::string& auth, const std::string& path);
-
-  // Event type.
-  enum Event {
-    UNKNOWN,
-    PUT,
-    PATCH
-  };
-
-  static inline std::string EventToName(Event event) {
-    switch(event)  {
-      case UNKNOWN:
-        return "UNKNOWN";
-      case PUT:
-        return "PUT";
-      case PATCH:
-        return "PATCH";
-      default:
-        return "INVALID_EVENT_" + event;
-    }
-  }
-
-  // Read next json encoded `event` from stream.
-  virtual Event read(std::string& event);
 };
 
 #endif // firebase_h

--- a/src/Firebase.h
+++ b/src/Firebase.h
@@ -29,12 +29,6 @@
 #include "FirebaseError.h"
 #include "FirebaseObject.h"
 
-class FirebaseGet;
-class FirebaseSet;
-class FirebasePush;
-class FirebaseRemove;
-class FirebaseStream;
-
 // Firebase REST API client.
 class Firebase {
  public:
@@ -43,24 +37,19 @@ class Firebase {
   const std::string& auth() const;
 
   // Fetch json encoded `value` at `path`.
-  FirebaseGet get(const std::string& path);
-  virtual std::unique_ptr<FirebaseGet> getPtr(const std::string& path);
+  void get(const std::string& path);
 
   // Set json encoded `value` at `path`.
-  FirebaseSet set(const std::string& path, const std::string& json);
-  virtual std::unique_ptr<FirebaseSet> setPtr(const std::string& path, const std::string& json);
+  void set(const std::string& path, const std::string& json);
 
   // Add new json encoded `value` to list at `path`.
-  FirebasePush push(const std::string& path, const std::string& json);
-  virtual std::unique_ptr<FirebasePush> pushPtr(const std::string& path, const std::string& json);
+  void push(const std::string& path, const std::string& json);
 
   // Delete value at `path`.
-  FirebaseRemove remove(const std::string& path);
-  virtual std::unique_ptr<FirebaseRemove> removePtr(const std::string& path);
+  void remove(const std::string& path);
 
   // Start a stream of events that affect value at `path`.
-  FirebaseStream stream(const std::string& path);
-  virtual std::unique_ptr<FirebaseStream> streamPtr(const std::string& path);
+  void stream(const std::string& path);
 
  protected:
   // Used for testing.
@@ -72,20 +61,19 @@ class Firebase {
   std::string auth_;
 };
 
+
 class FirebaseCall {
  public:
-  FirebaseCall() {}
-  FirebaseCall(const std::string& host, const std::string& auth,
-               const char* method, const std::string& path,
-               const std::string& data = "",
-               const std::shared_ptr<FirebaseHttpClient> http = NULL);
+  FirebaseCall(const std::shared_ptr<FirebaseHttpClient> http = NULL) : http_(http) {}
   virtual ~FirebaseCall();
 
-  virtual const FirebaseError& error() const {
+  const FirebaseError& error() const {
     return error_;
   }
 
-  virtual const std::string& response() const {
+  void analyzeError(char* method, int status, const std::string & path_with_auth);
+
+  const std::string& response() const {
     return response_;
   }
 
@@ -98,59 +86,22 @@ class FirebaseCall {
   std::shared_ptr<StaticJsonBuffer<FIREBASE_JSONBUFFER_SIZE>> buffer_;
 };
 
-class FirebaseGet : public FirebaseCall {
- public:
-  FirebaseGet() {}
-  FirebaseGet(const std::string& host, const std::string& auth,
-              const std::string& path, const std::shared_ptr<FirebaseHttpClient> http = NULL);
-
- private:
-  std::string json_;
+class FirebaseRequest : public FirebaseCall {
+  public:
+    FirebaseRequest(const std::shared_ptr<FirebaseHttpClient> http = NULL) : FirebaseCall(http) { }
+    virtual ~FirebaseRequest() {}
+    int sendRequest(const std::string& host, const std::string& auth,
+      char* method, const std::string& path, const std::string& data = "");
 };
-
-class FirebaseSet: public FirebaseCall {
- public:
-  FirebaseSet() {}
-  FirebaseSet(const std::string& host, const std::string& auth,
-              const std::string& path, const std::string& value, const std::shared_ptr<FirebaseHttpClient> http = NULL);
-
-
- private:
-  std::string json_;
-};
-
-class FirebasePush : public FirebaseCall {
- public:
-  FirebasePush() {}
-  FirebasePush(const std::string& host, const std::string& auth,
-               const std::string& path, const std::string& value, const std::shared_ptr<FirebaseHttpClient> http = NULL);
-  virtual ~FirebasePush() {}
-
-  virtual const std::string& name() const {
-    return name_;
-  }
-
- private:
-  std::string name_;
-};
-
-class FirebaseRemove : public FirebaseCall {
- public:
-  FirebaseRemove() {}
-  FirebaseRemove(const std::string& host, const std::string& auth,
-                 const std::string& path, const std::shared_ptr<FirebaseHttpClient> http = NULL);
-};
-
 
 class FirebaseStream : public FirebaseCall {
  public:
-  FirebaseStream() {}
-  FirebaseStream(const std::string& host, const std::string& auth,
-                 const std::string& path, const std::shared_ptr<FirebaseHttpClient> http = NULL);
+  FirebaseStream(const std::shared_ptr<FirebaseHttpClient> http = NULL) : FirebaseCall(http) { }
   virtual ~FirebaseStream() {}
 
   // Return if there is any event available to read.
-  virtual bool available();
+  bool available();
+  void startStreaming(const std::string& host, const std::string& auth, const std::string& path);
 
   // Event type.
   enum Event {
@@ -174,13 +125,6 @@ class FirebaseStream : public FirebaseCall {
 
   // Read next json encoded `event` from stream.
   virtual Event read(std::string& event);
-
-  const FirebaseError& error() const {
-    return _error;
-  }
-
- private:
-  FirebaseError _error;
 };
 
 #endif // firebase_h

--- a/src/FirebaseArduino.cpp
+++ b/src/FirebaseArduino.cpp
@@ -25,15 +25,19 @@ void FirebaseArduino::begin(const String& host, const String& auth) {
 }
 
 void FirebaseArduino::initStream() {
-  stream_http_.reset(FirebaseHttpClient::create());
-  stream_http_->setReuseConnection(true);
-  stream_.reset(new FirebaseStream(stream_http_));
+  if (stream_http_.get() == nullptr) {
+    stream_http_.reset(FirebaseHttpClient::create());
+    stream_http_->setReuseConnection(true);
+    stream_.reset(new FirebaseStream(stream_http_));
+  }
 }
 
 void FirebaseArduino::initRequest() {
-  req_http_.reset(FirebaseHttpClient::create());
-  req_http_->setReuseConnection(true);
-  req_.reset(new FirebaseRequest(req_http_));
+  if (req_http_.get() == nullptr) {
+    req_http_.reset(FirebaseHttpClient::create());
+    req_http_->setReuseConnection(true);
+    req_.reset(new FirebaseRequest(req_http_));
+  }
 }
 
 String FirebaseArduino::pushInt(const String& path, int value) {

--- a/src/FirebaseArduino.h
+++ b/src/FirebaseArduino.h
@@ -37,7 +37,7 @@ class FirebaseArduino {
    * \param host Your firebase db host, usually X.firebaseio.com.
    * \param auth Optional credentials for the db, a secret or token.
    */
-  void begin(const String& host, const String& auth = "");
+  virtual void begin(const String& host, const String& auth = "");
 
   /**
    * Appends the integer value to the node at path.
@@ -77,7 +77,7 @@ class FirebaseArduino {
    * \param value String value that you wish to append to the node.
    * \return The unique key of the new child node.
    */
-  String pushString(const String& path, const String& value);
+  virtual String pushString(const String& path, const String& value);
 
   /**
    * Appends the JSON data to the node at path.
@@ -123,7 +123,7 @@ class FirebaseArduino {
    * \param path The path inside of your db to the node you wish to update.
    * \param value String value that you wish to write.
    */
-  void setString(const String& path, const String& value);
+  virtual void setString(const String& path, const String& value);
 
   /**
    * Writes the JSON data to the node located at path.
@@ -157,7 +157,7 @@ class FirebaseArduino {
    * \param path The path to the node you wish to retrieve.
    * \return The string value located at that path. Will only be populated if success() is true.
    */
-  String getString(const String& path);
+  virtual String getString(const String& path);
 
   /**
    * Gets the boolean value located at path.
@@ -181,7 +181,7 @@ class FirebaseArduino {
    * \param path The path to the node you wish to remove,
    * including all of its children.
    */
-  void remove(const String& path);
+  virtual void remove(const String& path);
 
   /**
    * Starts streaming any changes made to the node located at path, including
@@ -198,7 +198,7 @@ class FirebaseArduino {
    * stream() has been called.
    * \return If a new event is ready.
    */
-  bool available();
+  virtual bool available();
 
   /**
    * Reads the next event in a stream. This is only meaningful once stream() has
@@ -206,7 +206,7 @@ class FirebaseArduino {
    * \return FirebaseObject will have ["type"] that describes the event type, ["path"]
    * that describes the effected path and ["data"] that was updated.
    */
-  FirebaseObject readEvent();
+  virtual FirebaseObject readEvent();
 
   /**
    * \return Whether the last command was successful.
@@ -221,7 +221,7 @@ class FirebaseArduino {
   /**
    * \return Error message from last command if failed() is true.
    */
-  const String& error();
+  virtual const String& error();
  private:
   std::string host_;
   std::string auth_;

--- a/src/FirebaseArduino.h
+++ b/src/FirebaseArduino.h
@@ -191,7 +191,7 @@ class FirebaseArduino {
    * monitoring available() and calling readEvent() to get new events.
    * \param path The path inside of your db to the node you wish to monitor.
    */
-  void stream(const String& path);
+  virtual void stream(const String& path);
 
   /**
    * Checks if there are new events available. This is only meaningful once

--- a/src/FirebaseArduino.h
+++ b/src/FirebaseArduino.h
@@ -226,7 +226,14 @@ class FirebaseArduino {
   std::string host_;
   std::string auth_;
   FirebaseError error_;
-  std::shared_ptr<FirebaseHttpClient> http_;
+  std::shared_ptr<FirebaseHttpClient> req_http_;
+  std::shared_ptr<FirebaseRequest> req_;
+  std::shared_ptr<FirebaseHttpClient> stream_http_;
+  std::shared_ptr<FirebaseStream> stream_;
+
+  void initStream();
+  void initRequest();
+  void getRequest(const String& path);
 };
 
 extern FirebaseArduino Firebase;

--- a/src/FirebaseHttpClient.h
+++ b/src/FirebaseHttpClient.h
@@ -33,18 +33,7 @@ class FirebaseHttpClient {
 
   virtual std::string errorToString(int error_code) = 0;
 
-  bool isStreaming() const {
-    return _streaming != "";
-  }
-  std::string getStreamingPath() const {
-    return _streaming;
-  }
-  void setStreaming(const std::string& path) {
-    _streaming = path;
-  }
  protected:
-  std::string _streaming = "";
-
   static const uint16_t kFirebasePort = 443;
 };
 


### PR DESCRIPTION
- This refactoring is fully compatible with previous FirebaseArduino.h interface and will use same or less amount of RAM if used in one-way mode (stream-only or get/set only).

- From now on, you won't need two instances of FirebaseArduino in order to be able to stream and change values at the same time: second https connection will be created dynamically and work while you are using stream mode. Bi-directional operation does require almost twice as much RAM, leaving only about 10k left for vanilla sample in ESP8266. You will also need to use ESP8266 Arduino core [2.4.1](https://github.com/esp8266/Arduino/tree/2.4.1) at the very least (that's when bi-directional support became possible due to fixes in https context). 

- Internal classes have been refactored into 2 to simplify development in future.
- contrib/src/modem was adjusted to use FirebaseArduino, but has not been tested enough. please let me know if you still use it and if you encounter any bugs.
